### PR TITLE
General Rewrite - Exposing new API

### DIFF
--- a/jquery.color.js
+++ b/jquery.color.js
@@ -1,129 +1,165 @@
 /*
  * jQuery Color Animations
- * Copyright 2007 John Resig
+ * Copyright 2011 John Resig
  * Released under the MIT and GPL licenses.
  */
 
-(function(jQuery){
+(function($){
 
-    // We override the animation for all of these color styles
-    jQuery.each(['backgroundColor', 'borderBottomColor', 'borderLeftColor', 'borderRightColor', 'borderTopColor', 'color', 'outlineColor'], function(i,attr){
-        jQuery.fx.step[attr] = function(fx){
-            if ( !fx.colorInit ) {
-                fx.start = getColor( fx.elem, attr );
-                fx.end = getRGB( fx.end );
-                fx.colorInit = true;
-            }
+	var stepHooks = 'backgroundColor borderBottomColor borderLeftColor borderRightColor borderTopColor color outlineColor'.split(' '),
+		rrgb = /rgb\(\s*([0-9]{1,3})\s*,\s*([0-9]{1,3})\s*,\s*([0-9]{1,3})\s*\)/,
+		rrgbpercent = /rgb\(\s*([0-9]+(?:\.[0-9]+)?)\%\s*,\s*([0-9]+(?:\.[0-9]+)?)\%\s*,\s*([0-9]+(?:\.[0-9]+)?)\%\s*\)/,
+		rlonghex = /#([a-fA-F0-9]{2})([a-fA-F0-9]{2})([a-fA-F0-9]{2})/,
+		rshorthex = /#([a-fA-F0-9])([a-fA-F0-9])([a-fA-F0-9])/,
 
-            fx.elem.style[attr] = "rgb(" + [
-                Math.max(Math.min( parseInt((fx.pos * (fx.end[0] - fx.start[0])) + fx.start[0]), 255), 0),
-                Math.max(Math.min( parseInt((fx.pos * (fx.end[1] - fx.start[1])) + fx.start[1]), 255), 0),
-                Math.max(Math.min( parseInt((fx.pos * (fx.end[2] - fx.start[2])) + fx.start[2]), 255), 0)
-            ].join(",") + ")";
-        }
-    });
+		// colors = jQuery.color.names
+		colors;
 
-    // Color Conversion functions from highlightFade
-    // By Blair Mitchelmore
-    // http://jquery.offput.ca/highlightFade/
+	// We override the animation for all of these color styles
+	$.each( stepHooks, function( i, attr ) {
 
-    // Parse strings looking for color tuples [255,255,255]
-    function getRGB(color) {
-        var result;
+		$.fx.step[ attr ] = function ( fx ) {
 
-        // Check if we're already dealing with an array of colors
-        if ( color && color.constructor == Array && color.length == 3 )
-            return color;
+			// parse start and end values the on first step
+			if ( !fx.colorInit ) {
+				fx.start = $.color.getColor( fx.elem, attr );
+				fx.end = $.color.parse( fx.end );
+				fx.colorInit = true;
+			}
 
-        // Look for rgb(num,num,num)
-        if (result = /rgb\(\s*([0-9]{1,3})\s*,\s*([0-9]{1,3})\s*,\s*([0-9]{1,3})\s*\)/.exec(color))
-            return [parseInt(result[1]), parseInt(result[2]), parseInt(result[3])];
+			var vals = [],
+				i = 0,
+				start = fx.start,
+				end = fx.end,
+				l = end.length;
+			
+			for ( ; i < l ; i++ ) {
+				// clamp values between 0 and 255, use ~~ to floor value
+				vals[ i ] = Math.min( ~~ Math.max( 
+					fx.pos * ( end[ i ] - start[ i ] ) + start[ i ] 
+				, 0 ), 255);
+			}
 
-        // Look for rgb(num%,num%,num%)
-        if (result = /rgb\(\s*([0-9]+(?:\.[0-9]+)?)\%\s*,\s*([0-9]+(?:\.[0-9]+)?)\%\s*,\s*([0-9]+(?:\.[0-9]+)?)\%\s*\)/.exec(color))
-            return [parseFloat(result[1])*2.55, parseFloat(result[2])*2.55, parseFloat(result[3])*2.55];
+			fx.elem.style[ attr ] = "rgb(" + vals.join(",") + ")";
 
-        // Look for #a0b1c2
-        if (result = /#([a-fA-F0-9]{2})([a-fA-F0-9]{2})([a-fA-F0-9]{2})/.exec(color))
-            return [parseInt(result[1],16), parseInt(result[2],16), parseInt(result[3],16)];
+		};
+	});
 
-        // Look for #fff
-        if (result = /#([a-fA-F0-9])([a-fA-F0-9])([a-fA-F0-9])/.exec(color))
-            return [parseInt(result[1]+result[1],16), parseInt(result[2]+result[2],16), parseInt(result[3]+result[3],16)];
+	// Color Conversion functions originally from highlightFade
+	// By Blair Mitchelmore
+	// http://jquery.offput.ca/highlightFade/
+	$.color = {
+		parse: function( color ) {
+			var result;
+			
+			// if the color is an array like [ 255, 255, 255 ]
+			if ( $.type( color ) == "array" && color.length == 3 ) {
+				return color;
+			}
 
-        // Look for rgba(0, 0, 0, 0) == transparent in Safari 3
-        if (result = /rgba\(0, 0, 0, 0\)/.exec(color))
-            return colors['transparent'];
+			// Look for rgb(num,num,num)
+			if ( result = rrgb.exec( color ) ) {
+				return [
+					parseInt( result[ 1 ], 10 ),
+					parseInt( result[ 2 ], 10 ),
+					parseInt( result[ 3 ], 10 )
+				];
+			}
 
-        // Otherwise, we're most likely dealing with a named color
-        return colors[jQuery.trim(color).toLowerCase()];
-    }
+			// Look for rgb(num%,num%,num%)
+			if ( result = rrgbpercent.exec( color ) ) {
+				return [ 
+					~~( result[ 1 ] / 100 ) * 255,
+					~~( result[ 2 ] / 100 ) * 255,
+					~~( result[ 3 ] / 100 ) * 255
+				];
+			}
 
-    function getColor(elem, attr) {
-        var color;
+			// Look for #a0b1c2
+			if ( result = rlonghex.exec( color ) ) {
+				return [
+					parseInt( result[ 1 ], 16 ),
+					parseInt( result[ 2 ], 16 ),
+					parseInt( result[ 3 ], 16 )
+				];
+			}
 
-        do {
-            color = jQuery.curCSS(elem, attr);
+			// Look for #fff
+			if ( result = rshorthex.exec( color ) ) {
+				return [
+					parseInt( result[ 1 ] + result[ 1 ], 16 ),
+					parseInt( result[ 2 ] + result[ 2 ], 16 ),
+					parseInt( result[ 3 ] + result[ 3 ], 16 )
+				];
+			}
 
-            // Keep going until we find an element that has color, or we hit the body
-            if ( color != '' && color != 'transparent' || jQuery.nodeName(elem, "body") )
-                break;
+			// return the named color, or default if we can't parse.
+			return colors[ $.trim( color ).toLowerCase() ] || colors[ '_default' ];
+		},
+		names: {
+			aqua: [ 0, 255, 255 ],
+			azure: [ 240, 255, 255 ],
+			beige: [ 245, 245, 220 ],
+			black: [ 0, 0, 0 ],
+			blue: [ 0, 0, 255 ],
+			brown: [ 165, 42, 42 ],
+			cyan: [ 0, 255, 255 ],
+			darkblue: [ 0, 0, 139 ],
+			darkcyan: [ 0, 139, 139 ],
+			darkgrey: [ 169, 169, 169 ],
+			darkgreen: [ 0, 100, 0 ],
+			darkkhaki: [ 189, 183, 107 ],
+			darkmagenta: [ 139, 0, 139 ],
+			darkolivegreen: [ 85, 107, 47 ],
+			darkorange: [ 255, 140, 0 ],
+			darkorchid: [ 153, 50, 204 ],
+			darkred: [ 139, 0, 0 ],
+			darksalmon: [ 233, 150, 122 ],
+			darkviolet: [ 148, 0, 211 ],
+			fuchsia: [ 255, 0, 255 ],
+			gold: [ 255, 215, 0 ],
+			green: [ 0, 128, 0 ],
+			indigo: [ 75, 0, 130 ],
+			khaki: [ 240, 230, 140 ],
+			lightblue: [ 173, 216, 230 ],
+			lightcyan: [ 224, 255, 255 ],
+			lightgreen: [ 144, 238, 144 ],
+			lightgrey: [ 211, 211, 211 ],
+			lightpink: [ 255, 182, 193 ],
+			lightyellow: [ 255, 255, 224 ],
+			lime: [ 0, 255, 0 ],
+			magenta: [ 255, 0, 255 ],
+			maroon: [ 128, 0, 0 ],
+			navy: [ 0, 0, 128 ],
+			olive: [ 128, 128, 0 ],
+			orange: [ 255, 165, 0 ],
+			pink: [ 255, 192, 203 ],
+			purple: [ 128, 0, 128 ],
+			violet: [ 128, 0, 128 ],
+			red: [ 255, 0, 0 ],
+			silver: [ 192, 192, 192 ],
+			white: [ 255, 255, 255 ],
+			yellow: [ 255, 255, 0 ],
+			transparent: [ 255, 255, 255 ],
+			'_default': [ 255, 255, 255 ]
+		},
+		getColor: function ( elem, attr ) {
+			var color;
 
-            attr = "backgroundColor";
-        } while ( elem = elem.parentNode );
+			do {
+				color = $.curCSS( elem, attr );
 
-        return getRGB(color);
-    };
+				// Keep going until we find an element that has color, or we hit the body
+				if ( color != '' && color != 'transparent' || $.nodeName( elem, "body" ) ) {
+					break;
+				}
 
-    // Some named colors to work with
-    // From Interface by Stefan Petre
-    // http://interface.eyecon.ro/
+				attr = "backgroundColor";
+			} while ( elem = elem.parentNode );
 
-    var colors = {
-        aqua:[0,255,255],
-        azure:[240,255,255],
-        beige:[245,245,220],
-        black:[0,0,0],
-        blue:[0,0,255],
-        brown:[165,42,42],
-        cyan:[0,255,255],
-        darkblue:[0,0,139],
-        darkcyan:[0,139,139],
-        darkgrey:[169,169,169],
-        darkgreen:[0,100,0],
-        darkkhaki:[189,183,107],
-        darkmagenta:[139,0,139],
-        darkolivegreen:[85,107,47],
-        darkorange:[255,140,0],
-        darkorchid:[153,50,204],
-        darkred:[139,0,0],
-        darksalmon:[233,150,122],
-        darkviolet:[148,0,211],
-        fuchsia:[255,0,255],
-        gold:[255,215,0],
-        green:[0,128,0],
-        indigo:[75,0,130],
-        khaki:[240,230,140],
-        lightblue:[173,216,230],
-        lightcyan:[224,255,255],
-        lightgreen:[144,238,144],
-        lightgrey:[211,211,211],
-        lightpink:[255,182,193],
-        lightyellow:[255,255,224],
-        lime:[0,255,0],
-        magenta:[255,0,255],
-        maroon:[128,0,0],
-        navy:[0,0,128],
-        olive:[128,128,0],
-        orange:[255,165,0],
-        pink:[255,192,203],
-        purple:[128,0,128],
-        violet:[128,0,128],
-        red:[255,0,0],
-        silver:[192,192,192],
-        white:[255,255,255],
-        yellow:[255,255,0],
-        transparent: [255,255,255]
-    };
+			return getRGB(color);
+		}
+	};
 
+	colors = $.color.names;
 })(jQuery);


### PR DESCRIPTION
# jQuery.color.names

An array containing _lower case_ strings to map named colors to RGB tuples.
# jQuery.color.parse( string )

Parses string values from CSS and returns a color _currently_ represented as an array that contains values for RGB from 0-255.

Supports: `#ffffff`, `#fff`, `rgb(255,255,255)`, `rgb(100%,100%,100.0%)`, `jQuery.color.names`

If it can't parse the value, it will return `jQuery.color.names[ '_default' ]`
# jQuery.color.getColor( DOMElement, attr )

A helper function used by the animate, but exposed in case someone needs the same functionality.  Returns the CSS value of `attr` converted to a color.  Will continues up the `DOMElement.parentNode` until it finds an element that exposes a `backgroundColor` if the defined property doesn't exist.
