### PR TITLE
Replace reference to $

### DIFF
--- a/jquery.color.js
+++ b/jquery.color.js
@@ -274,7 +274,7 @@ color.fn = jQuery.extend( color.prototype, {
 					});
 
 					// everything defined but alpha?
-					if ( inst[ cache ] && $.inArray( null, inst[ cache ].slice( 0, 3 ) ) < 0 ) {
+					if ( inst[ cache ] && jQuery.inArray( null, inst[ cache ].slice( 0, 3 ) ) < 0 ) {
 						// use the default of 1
 						inst[ cache ][ 3 ] = 1;
 						if ( space.from ) {


### PR DESCRIPTION
Because $ is not available in noConflict mode.
