### PR TITLE
Build: Use browserSets from testswarm config

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -227,7 +227,7 @@ grunt.registerTask( "testswarm", function( commit, configFile ) {
 				"jQuery color": config.testUrl + commit + "/test/index.html"
 			},
 			runMax: config.runMax,
-			browserSets: ["popular"]
+			browserSets: config.browserSets
 		}, function( err, passed ) {
 			if ( err ) {
 				grunt.log.error( err );


### PR DESCRIPTION
This is now a required property for configuration file.
The one on jQuery's Jenkins server already has it.

Matches what other jQuery projects are doing already and should fix the Jenkins build that is currently failing because support for browserSet `popular` has been removed.

http://jenkins.jquery.com/job/jQuery%20Color/130/