### PR TITLE
Make the library compatible with NPM

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,11 @@
   },
   "bugs": "https://github.com/jquery/jquery-color/issues",
   "license": "MIT",
+  "main": "jquery.color.js",
   "dependencies": {},
+  "peerDependencies": {
+    "jquery": ">=1.11.0"
+  },
   "devDependencies": {
     "grunt": "0.4.5",
     "grunt-bowercopy": "1.0.0",


### PR DESCRIPTION
NPM and other package managers like JSPM expect to have a main
attribute in package.json to specify which file should be returned
when someone requires the library. [[1]](https://docs.npmjs.com/files/package.json#main)

It also needs a list of required runtime dependencies [[2]](https://docs.npmjs.com/files/package.json#dependencies)

This is related to #84 

