### PR TITLE
Build: Add an npm test script

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   },
   "scripts": {
     "browserstack": "sh build/run-browserstack.sh",
-    "ci": "grunt ci"
+    "ci": "grunt ci",
+    "test": "grunt ci"
   },
   "maintainers": [
     {


### PR DESCRIPTION
This allows to run tests via `npm test` which is a standard convention
amongst npm packages.