### PR TITLE
Core: Don't reset alpha to 1 if all red, green, blue & alpha provided

### DIFF
--- a/jquery.color.js
+++ b/jquery.color.js
@@ -297,7 +297,10 @@ color.fn = jQuery.extend( color.prototype, {
 					if ( inst[ cache ] && jQuery.inArray( null, inst[ cache ].slice( 0, 3 ) ) < 0 ) {
 
 						// use the default of 1
-						inst[ cache ][ 3 ] = 1;
+						if ( inst[ cache ][ 3 ] == null ) {
+							inst[ cache ][ 3 ] = 1;
+						}
+
 						if ( space.from ) {
 							inst._rgba = space.from( inst[ cache ] );
 						}

--- a/test/unit/color.js
+++ b/test/unit/color.js
@@ -36,6 +36,18 @@ QUnit.test( "jQuery.Color( 255, 255, 255 )", function( assert ) {
 	}, assert );
 } );
 
+
+QUnit.test( "jQuery.Color({ red: 10, green: 20, blue: 30, alpha: 0.4 })", function( assert ) {
+	var blue = jQuery.Color( { red: 10, green: 20, blue: 30, alpha: 0.4 } );
+	testParts( blue, {
+		red: 10,
+		green: 20,
+		blue: 30,
+		alpha: 0.4
+	}, assert );
+	assert.ok( !blue._hsla, "No HSLA cache" );
+} );
+
 QUnit.test( "jQuery.Color( element, \"color\" )", function( assert ) {
 	var $div = jQuery( "<div>" ).css( "color", "#fff" );
 	assert.expect( 8 );
@@ -81,6 +93,17 @@ QUnit.test( "jQuery.Color({ alpha: 1 })", function( assert ) {
 		green: null,
 		blue: null,
 		alpha: 1
+	}, assert );
+	assert.ok( !blue._hsla, "No HSLA cache" );
+} );
+
+QUnit.test( "jQuery.Color({ alpha: 0.4 })", function( assert ) {
+	var blue = jQuery.Color( { alpha: 0.4 } );
+	testParts( blue, {
+		red: null,
+		green: null,
+		blue: null,
+		alpha: 0.4
 	}, assert );
 	assert.ok( !blue._hsla, "No HSLA cache" );
 } );


### PR DESCRIPTION
Before this commit the following code:

    jQuery.Color( { red: 10, green: 20, blue: 30, alpha: 0.4 } )

was incorrectly creating a Color object with the alpha property set to 1.

Fixes #58