### PR TITLE
Core: Add support for hex colors with alpha transparency

### DIFF
--- a/jquery.color.js
+++ b/jquery.color.js
@@ -54,6 +54,18 @@
 		}, {
 
 			// this regex ignores A-F because it's compared against an already lowercased string
+			re: /#([a-f0-9]{2})([a-f0-9]{2})([a-f0-9]{2})([a-f0-9]{2})/,
+			parse: function( execResult ) {
+				return [
+					parseInt( execResult[ 1 ], 16 ),
+					parseInt( execResult[ 2 ], 16 ),
+					parseInt( execResult[ 3 ], 16 ),
+					( parseInt( execResult[ 4 ], 16 ) / 255.0 ).toFixed( 2 )
+				];
+			}
+		}, {
+
+			// this regex ignores A-F because it's compared against an already lowercased string
 			re: /#([a-f0-9]{2})([a-f0-9]{2})([a-f0-9]{2})/,
 			parse: function( execResult ) {
 				return [

--- a/test/unit/color.js
+++ b/test/unit/color.js
@@ -170,6 +170,27 @@ var sevens = {
 };
 parseTest( "#777", sevens );
 parseTest( "#777777", sevens );
+parseTest( "#77777726", {
+	expect: 4,
+	red: 119,
+	green: 119,
+	blue: 119,
+	alpha: 0.15
+} );
+parseTest( "#777777FF", {
+	expect: 4,
+	red: 119,
+	green: 119,
+	blue: 119,
+	alpha: 1
+} );
+parseTest( "#77777700", {
+	expect: 4,
+	red: 119,
+	green: 119,
+	blue: 119,
+	alpha: 0
+} );
 
 var fiftypercent = {
 	expect: 4,


### PR DESCRIPTION
Hex colors with alpha transparency are supported in Firefox and Chrome,
at least, perhaps others as well:

  eg. #0099bbff (is #0099bb color with ff alpha)

However, jquery-color would convert this hex value to an rgb value
losing the alpha transparency:

  eg. rgb(0, 153, 187)