### PR TITLE
Tests: Fix project name for any BrowserStack runs

### DIFF
--- a/test/runner/browsers.js
+++ b/test/runner/browsers.js
@@ -64,7 +64,7 @@ export async function createBrowserWorker( url, browser, options, restarts = 0 )
 		worker = await createWorker( {
 			...browser,
 			url: encodeURI( url ),
-			project: "jquery",
+			project: "jquery-color",
 			build: `Run ${ runId }`,
 
 			// This is the maximum timeout allowed


### PR DESCRIPTION
- this was accidentally copied over from core