### PR TITLE
Replace deprecated substr()

### DIFF
--- a/jquery.color.js
+++ b/jquery.color.js
@@ -452,7 +452,7 @@ color.fn = jQuery.extend( color.prototype, {
 		return "#" + jQuery.map( rgba, function( v ) {
 
 			// default to 0 when nulls exist
-			return ( "0" + ( v || 0 ).toString( 16 ) ).substr( -2 );
+			return ( "0" + ( v || 0 ).toString( 16 ) ).slice( -2 );
 		} ).join( "" );
 	},
 	toString: function() {


### PR DESCRIPTION
This function is giving out deprecation warnings on modern IDEs. Replacing it with more modern and [very well-supported](https://caniuse.com/mdn-javascript_builtins_string_slice) alternative.