### PR TITLE
Core: Fix parsing to preserve CSS variables with fallback colors

### DIFF
--- a/jquery.color.js
+++ b/jquery.color.js
@@ -35,7 +35,7 @@
 
 	// a set of RE's that can match strings and generate color tuples.
 	stringParsers = [ {
-			re: /rgba?\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})\s*(?:,\s*(\d?(?:\.\d+)?)\s*)?\)/,
+			re: /^\s*rgba?\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})\s*(?:,\s*(\d?(?:\.\d+)?)\s*)?\)/,
 			parse: function( execResult ) {
 				return [
 					execResult[ 1 ],
@@ -45,7 +45,7 @@
 				];
 			}
 		}, {
-			re: /rgba?\(\s*(\d+(?:\.\d+)?)\%\s*,\s*(\d+(?:\.\d+)?)\%\s*,\s*(\d+(?:\.\d+)?)\%\s*(?:,\s*(\d?(?:\.\d+)?)\s*)?\)/,
+			re: /^\s*rgba?\(\s*(\d+(?:\.\d+)?)\%\s*,\s*(\d+(?:\.\d+)?)\%\s*,\s*(\d+(?:\.\d+)?)\%\s*(?:,\s*(\d?(?:\.\d+)?)\s*)?\)/,
 			parse: function( execResult ) {
 				return [
 					execResult[ 1 ] * 2.55,
@@ -57,7 +57,7 @@
 		}, {
 
 			// this regex ignores A-F because it's compared against an already lowercased string
-			re: /#([a-f0-9]{2})([a-f0-9]{2})([a-f0-9]{2})([a-f0-9]{2})?/,
+			re: /^\s*#([a-f0-9]{2})([a-f0-9]{2})([a-f0-9]{2})([a-f0-9]{2})?/,
 			parse: function( execResult ) {
 				return [
 					parseInt( execResult[ 1 ], 16 ),
@@ -71,7 +71,7 @@
 		}, {
 
 			// this regex ignores A-F because it's compared against an already lowercased string
-			re: /#([a-f0-9])([a-f0-9])([a-f0-9])([a-f0-9])?/,
+			re: /^\s*#([a-f0-9])([a-f0-9])([a-f0-9])([a-f0-9])?/,
 			parse: function( execResult ) {
 				return [
 					parseInt( execResult[ 1 ] + execResult[ 1 ], 16 ),
@@ -84,7 +84,7 @@
 				];
 			}
 		}, {
-			re: /hsla?\(\s*(\d+(?:\.\d+)?)\s*,\s*(\d+(?:\.\d+)?)\%\s*,\s*(\d+(?:\.\d+)?)\%\s*(?:,\s*(\d?(?:\.\d+)?)\s*)?\)/,
+			re: /^\s*hsla?\(\s*(\d+(?:\.\d+)?)\s*,\s*(\d+(?:\.\d+)?)\%\s*,\s*(\d+(?:\.\d+)?)\%\s*(?:,\s*(\d?(?:\.\d+)?)\s*)?\)/,
 			space: "hsla",
 			parse: function( execResult ) {
 				return [

--- a/test/unit/color.js
+++ b/test/unit/color.js
@@ -172,6 +172,10 @@ var sevens = {
 };
 parseTest( "#777", sevens );
 parseTest( "#777777", sevens );
+
+// Tolerate whitespace. https://github.com/jquery/jquery-ui/issues/2411
+parseTest( "  #777  ", sevens );
+parseTest( "  #777777  ", sevens );
 parseTest( "#77777726", {
 	expect: 4,
 	red: 119,
@@ -237,6 +241,9 @@ parseTest( "rgba(127, 127, 127, 0.5)", fiftypercentalpha );
 parseTest( "rgba(50%, 50%, 50%, 0.5)", fiftypercentalpha );
 parseTest( "rgba(127, 127, 127, .5)", fiftypercentalpha );
 parseTest( "rgba(50%, 50%, 50%, .5)", fiftypercentalpha );
+
+// Tolerate whitespace. https://github.com/jquery/jquery-ui/issues/2411
+parseTest( "  rgba( 50%, 50%, 50%, .5 )  ", fiftypercentalpha );
 parseTest( "rgba(0, 0, 0, 0)", {
 	expect: 4,
 	red: null,
@@ -673,6 +680,21 @@ QUnit.test( "Setting CSS to transparent", function( assert ) {
 
 	el.css( "backgroundColor", "transparent" );
 	assert.equal( jQuery.Color( el[ 0 ].style.backgroundColor ).alpha(), 0, "CSS was set to transparent" );
+} );
+
+QUnit.test.each( "Setting CSS to a variable", {
+	"without fallback": [ "var(--meh)", "var(--meh)" ],
+	"without fallback and whitespace": [ "  var( --meh )  ", "var( --meh )" ],
+	"with fallback": [ "var(--meh,#ff0077)", "var(--meh,#ff0077)" ],
+	"with fallback and whitespace": [ "  var( --meh,  #ff0077 )  ", "var( --meh,  #ff0077 )" ]
+}, function( assert, data ) {
+	var el = jQuery( "<div></div>" ).css( { color: data[ 0 ] } );
+	assert.expect( 1 );
+
+	// Support: Safari 26
+	// WebKit fails to trim trailing whitespace. https://bugs.webkit.org/show_bug.cgi?id=320186
+	var actual = el[ 0 ].style.color.replace( / +$/, "" );
+	assert.equal( actual, data[ 1 ], "Declared value" );
 } );
 
 QUnit.test( "jQuery.Color.hook() - Create new hooks for color properties", function( assert ) {


### PR DESCRIPTION
Before:
```js
$('<div>').css('color', 'var(--color-base, #202122)').attr('style');
//> color: rgb(32, 33, 34);
```

After:
```js
$('<div>').css('color', 'var(--color-base, #202122)').attr('style');
//> var(--color-base, #202122)
```

The "with fallback" test cases fail without the patch:
> message:  Declared value
> expected: "rgba(255, 255, 0, 0)"
> actual:   "var(--example-not-found,#ff0077)"

To minimise the impact of this change, make whitespace tolerance explicit in the regex. This was previousluy implict because the regex wasn't anchored. Whitespace tolerance isn't just theoretical back-compat, it matches native DOM behaviour and (without this plugin) jQuery Core behavior:

```js
var d = document.createElement('div');
d.style.color = '    #202FF2   ';
d.style.color;
//> "rgb(32, 47, 242)"
```

Fixes https://github.com/jquery/jquery-ui/issues/2411.